### PR TITLE
Fix bug that break remote ip sometime.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Makefile for mod_remoteip.c (gmake)
 APXS=$(shell which apxs || which apxs2) 
 
-default: mod_remoteip.o
+default: mod_remoteip.la
 
-mod_remoteip.o: mod_remoteip.c
+mod_remoteip.la: mod_remoteip.c
 	$(APXS) -c -n mod_remoteip.so mod_remoteip.c
 
-install: mod_remoteip.o
+install: mod_remoteip.la
 	$(APXS) -i -n mod_remoteip.so mod_remoteip.la
 
 clean:


### PR DESCRIPTION
同じクライアントからリクエストを何度か連続して送るとremote_ipが壊れる問題を直してみました。

こんなことが起きていたみたいです。
- `c->remote_ip`に`r->hook`から確保した文字列を設定
- リクエストの処理が終わって`r`が破棄される
- `c`はまだ破棄されない
- 同じ接続元からのリクエストがあって`c`が使いまわされる
- `c->remote_ip`は開放済みの場所を指している
- `c->remote_ip`が指している場所に全然関係ないものが入ってしまう
